### PR TITLE
feat: add saves

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
         <div id="active-color"></div>
       </div>
       <div id="game"></div>
+      <div id="saves"></div>
     </div>
     <script src="./main.js" type="module"></script>
   </body>

--- a/main.js
+++ b/main.js
@@ -117,6 +117,8 @@
   }
 
   function handleKeydown(event) {
+    // Save buttons are activated when the save is applied, so we remove that on
+    // the next interaction.
     document
       .querySelectorAll(".active")
       .forEach((el) => el.classList.remove("active"));
@@ -169,6 +171,10 @@
         break;
       }
       case "s": {
+        // There is probably a clever way to handle Mac/Windows here, but this
+        // seemed the easiest option.
+        // For the record, this will be true for ctrl+s on Mac and windows+s on
+        // Windows.
         if (event.ctrlKey || event.metaKey) {
           event.preventDefault();
           save();
@@ -187,13 +193,14 @@
   // Saves
 
   const saveKey = "paint-pig.saves";
+  const coordinatesEls = document.querySelectorAll("[data-coordinates]");
+  const savesContainerEl = document.getElementById("saves");
 
   function applySave(i) {
     const data = JSON.parse(localStorage.getItem(saveKey), "[]");
     const save = data[i];
-    const nextMAP = {};
     if (!save) return;
-    const coordinatesEls = document.querySelectorAll("[data-coordinates]");
+    const nextMAP = {};
     coordinatesEls.forEach((el) => {
       const coordinates = el.dataset.coordinates;
       const hsl = save[coordinates];
@@ -218,6 +225,7 @@
         .replace(/%/g, "")
         .split(", ")
         .map((s) => parseFloat(s));
+      // Ignore white when calculating the average.
       if (h !== 0 && s !== 100) {
         count++;
         hsl[0] += h;
@@ -231,19 +239,18 @@
 
   function renderSaves() {
     const data = JSON.parse(localStorage.getItem(saveKey) || "[]");
-    const container = document.getElementById("saves");
     if (!data.length) {
-      return (container.textContent = "No saves");
+      return (savesContainerEl.textContent = "No saves");
     }
     let html = "<b>Saves</b>";
     data.forEach((saveData, i) => {
-      html += `<button aria-label="Apply save ${
+      html += `<span aria-label="Apply save ${
         i + 1
       }}" data-save="${i}" style="background-color: ${getSaveColorHSL(
         saveData
-      )}; opacity: ${100 - 25 * i}%">${["j", "k", "l"][i]}</button>`;
+      )}; opacity: ${100 - 25 * i}%">${["j", "k", "l"][i]}</span>`;
     });
-    container.innerHTML = html;
+    savesContainerEl.innerHTML = html;
   }
 
   function save() {
@@ -258,13 +265,6 @@
     localStorage.setItem(saveKey, JSON.stringify(nextSave));
     renderSaves();
   }
-
-  document.addEventListener("click", (event) => {
-    if (event.target.dataset.save) {
-      event.preventDefault();
-      applySave(Number(event.target.dataset.save));
-    }
-  });
 
   renderSaves();
 

--- a/styles.css
+++ b/styles.css
@@ -16,10 +16,6 @@ body {
   margin: 0;
 }
 
-button {
-  font: inherit;
-}
-
 header {
   text-align: center;
   padding: 10px 0;

--- a/styles.css
+++ b/styles.css
@@ -5,12 +5,19 @@
   --green: hsl(130, 69%, 48%);
   --blue: hsl(211, 100%, 50%);
   --violet: hsl(280, 68%, 60%);
+
+  --button-size: 40px;
+  --button-border: 1px solid hsla(0, 0%, 0%, 50%);
 }
 
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
     Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   margin: 0;
+}
+
+button {
+  font: inherit;
 }
 
 header {
@@ -33,8 +40,6 @@ header > * {
 }
 
 .toolbar {
-  --button-size: 40px;
-  --button-border: 1px solid hsla(0, 0%, 0%, 50%);
   align-items: center;
   background-color: #333;
   border-top-left-radius: 2px;
@@ -69,12 +74,14 @@ body[data-active-color="o"] [data-color-key="o"],
 body[data-active-color="y"] [data-color-key="y"],
 body[data-active-color="g"] [data-color-key="g"],
 body[data-active-color="b"] [data-color-key="b"],
-body[data-active-color="p"] [data-color-key="p"] {
+body[data-active-color="p"] [data-color-key="p"],
+#saves [data-save].active {
   transform: scale(1.15);
   box-shadow: 0 2px 8px hsla(0, 0%, 0%, 80%);
 }
 
-#color-menu [data-color-key] {
+#color-menu [data-color-key],
+#saves [data-save] {
   align-items: center;
   border: var(--button-border);
   border-radius: 2px;
@@ -108,9 +115,18 @@ body[data-active-color="p"] [data-color-key="p"] {
   padding: 2px;
 }
 
-#game .coordinate {
+#game [data-coordinates] {
   align-items: center;
   display: flex;
   font-size: 30px;
   justify-content: center;
+}
+
+#saves {
+  align-items: center;
+  display: flex;
+  gap: 4px;
+  height: var(--button-size);
+  justify-content: flex-end;
+  padding-top: 4px;
 }


### PR DESCRIPTION
This PR adds a saving feature and removes the `blends` data from storage.

The number of saves was limited to three because I wanted to keep the functionality limited to the keyboard, and there aren't many uninterrupted stretches of keys left on a traditional keyboard. Numbers would have been good, but I already used 0 and 1 for black and white. If the desire arises, we could add a fourth save and remap to:
- UIOP
- HJKL
- ASDF
- 2-9